### PR TITLE
Reestruturação do domínio da aplicação

### DIFF
--- a/adapter/output/database/cliente.go
+++ b/adapter/output/database/cliente.go
@@ -41,8 +41,6 @@ func (c ClienteDB) CopyToClienteDomain() domain.ClienteDomain {
 	return domain.ClienteDomain{
 		ID:           c.ID,
 		Nome:         c.Nome,
-		Telefone:     c.Telefone,
-		Endereco:     c.Endereco,
 		DataCadastro: c.DataCadastro,
 	}
 }

--- a/adapter/output/database/db/init.sql
+++ b/adapter/output/database/db/init.sql
@@ -1,44 +1,106 @@
 create schema petshop_api
 
 -- auto-generated definition
+    create table endereco
+    (
+        id         serial       not null
+            constraint petshop_api_endereco_pkey primary key,
+        logradouro varchar(255) not null,
+        numero     varchar(255) not null
+    )
+
+    create
+        unique index petshop_api_endereco_id_uindex
+        on endereco (id)
+
     create table cliente
     (
-        id            serial       not null
+        id             serial       not null
             constraint petshop_api_cliente_pkey primary key,
-        nome          varchar(255) not null,
-        telefone      json         NOT NULL,
-        endereco      varchar(255) not null,
-        email         varchar(255) not null,
-        data_cadastro timestamp default timezone('BRT'::text, now())
+        nome           varchar(255) not null,
+        email          varchar(255) not null,
+        data_cadastro  timestamp default timezone('BRT'::text, now()),
+        fk_id_endereco int          not null,
+        FOREIGN KEY (fk_id_endereco) references endereco (id)
     )
 
     create
         unique index petshop_api_cliente_id_uindex
         on cliente (id)
 
+    create table telefone
+    (
+        id            serial       not null
+            constraint petshop_api_telefone_pkey primary key,
+        numero        varchar(255) not null,
+        ddd           varchar(255) not null,
+        tipo_telefone varchar(255) not null,
+        fk_id_cliente int          not null,
+        FOREIGN KEY (fk_id_cliente) references cliente (id)
+    )
+
+    create
+        unique index petshop_api_telefone_id_uindex
+        on telefone (id)
+
+    create table especie
+    (
+        id   serial       not null
+            constraint petshop_api_especie_pkey primary key,
+        nome varchar(255) not null
+    )
+
+    create
+        unique index petshop_api_especie_id_uindex
+        on especie (id)
+
+    create table raca
+    (
+        id            serial       not null
+            constraint petshop_api_raca_pkey primary key,
+        nome          varchar(255) not null,
+        fk_id_especie int          not null,
+        FOREIGN KEY (fk_id_especie) references especie (id)
+    )
+
+    create
+        unique index petshop_api_raca_id_uindex
+        on raca (id)
+
     create table pet
     (
         id              serial       not null
             constraint petshop_api_pet_pkey primary key,
         nome            varchar(255) not null,
-        especie         varchar(255) not null,
-        raca            varchar(255) not null,
         data_cadastro   timestamp default timezone('BRT'::text, now()),
-        data_nascimento date default timezone('BRT'::text, null),
+        data_nascimento date      default timezone('BRT'::text, null),
         fk_id_cliente   int          not null,
-        FOREIGN KEY (fk_id_cliente) references cliente (id)
+        fk_id_raca      int          not null,
+        FOREIGN KEY (fk_id_cliente) references cliente (id),
+        FOREIGN KEY (fk_id_raca) references raca (id)
     )
 
     create
         unique index petshop_api_pet_id_uindex
         on pet (id);
 
--- Create default clientes inserts
-INSERT INTO petshop_api.cliente (nome, telefone, endereco, email, data_cadastro)
-VALUES ('siclano', '{
-  "celular": "5521933235455"
-}', 'Av. Rio Branco, 156', 'siclano@gmail.com', now());
 
-INSERT INTO petshop_api.pet (nome, especie, raca, data_cadastro, data_nascimento, fk_id_cliente)
-VALUES ('Bingo', 'Cachorro', 'Bordercole', now(), to_date('12/12/2016','dd/MM/yyyy'), 1);
+-- Create default clientes inserts
+
+INSERT INTO petshop_api.endereco (logradouro, numero)
+VALUES ('Rua Jose Bonifácio', 1432);
+
+INSERT INTO petshop_api.cliente (nome, fk_id_endereco, email, data_cadastro)
+VALUES ('siclano', 1, 'siclano@gmail.com', now());
+
+INSERT INTO petshop_api.telefone (numero, ddd, tipo_telefone, fk_id_cliente)
+VALUES ('912345678', '72', 'celular', 1);
+
+INSERT INTO petshop_api.especie (nome) VALUES ('Canino');
+INSERT INTO petshop_api.especie (nome) VALUES ('Felino');
+
+INSERT INTO petshop_api.raca (nome, fk_id_especie) VALUES ('Pastor Alemao', 1);
+
+INSERT INTO petshop_api.pet (nome, data_cadastro, data_nascimento, fk_id_cliente, fk_id_raca)
+VALUES ('Rex', now(),  to_date('12/12/2016','dd/MM/yyyy'), 1, 1);
 

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -1,11 +1,37 @@
 package domain
 
-import "time"
+import (
+	"time"
+)
 
 type ClienteDomain struct {
 	ID           int64
 	Nome         string
-	Telefone     map[string]string // key: tipo telefone, val: telefone
-	Endereco     string
 	DataCadastro time.Time
+	Endereco     EnderecoDomain
+}
+
+type TelefoneDomain struct {
+	ID           int64
+	Numero       string
+	DDD          string
+	TipoTelefone string
+	Cliente      ClienteDomain
+}
+
+type EnderecoDomain struct {
+	ID         int64
+	Logradouro string
+	Numero     string
+}
+
+type Especie struct {
+	ID   int64
+	Nome string
+}
+
+type Raca struct {
+	ID      int64
+	Nome    string
+	Especie Especie
 }

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -8,7 +8,6 @@ type ClienteDomain struct {
 	ID           int64
 	Nome         string
 	DataCadastro time.Time
-	Endereco     EnderecoDomain
 }
 
 type TelefoneDomain struct {
@@ -16,7 +15,6 @@ type TelefoneDomain struct {
 	Numero       string
 	DDD          string
 	TipoTelefone string
-	Cliente      ClienteDomain
 }
 
 type EnderecoDomain struct {
@@ -25,13 +23,12 @@ type EnderecoDomain struct {
 	Numero     string
 }
 
-type Especie struct {
+type EspecieDomain struct {
 	ID   int64
 	Nome string
 }
 
-type Raca struct {
-	ID      int64
-	Nome    string
-	Especie Especie
+type RacaDomain struct {
+	ID   int64
+	Nome string
 }

--- a/application/service/cliente_test.go
+++ b/application/service/cliente_test.go
@@ -50,21 +50,13 @@ func TestCustomerService_Create(t *testing.T) {
 		{
 			Name: "sucesso ao salvar cliente",
 			Cliente: domain.ClienteDomain{
-				Telefone: map[string]string{
-					"celular": "5572983332244",
-				},
-				Nome:     "Fulano",
-				Endereco: "rua 5, casa 3",
+				Nome: "Fulano",
 			},
 			CustomerDomainDataBaseRepository: output.CustomerDomainDataBaseRepositoryMock{
 				SaveMock: func(contextControl domain.ContextControl, cliente domain.ClienteDomain) (domain.ClienteDomain, error) {
 					return domain.ClienteDomain{
-						ID: 1,
-						Telefone: map[string]string{
-							"celular": "5572983332244",
-						},
-						Nome:     "Fulano",
-						Endereco: "rua 5, casa 3",
+						ID:   1,
+						Nome: "Fulano",
 					}, nil
 				},
 			},
@@ -74,12 +66,8 @@ func TestCustomerService_Create(t *testing.T) {
 				},
 			},
 			ExpectedResult: domain.ClienteDomain{
-				ID: 1,
-				Telefone: map[string]string{
-					"celular": "5572983332244",
-				},
-				Nome:     "Fulano",
-				Endereco: "rua 5, casa 3",
+				ID:   1,
+				Nome: "Fulano",
 			},
 			ExpectedError: nil,
 		},


### PR DESCRIPTION
Atendendo a pedidos eu refiz a estrutura base das "entidades" de domínio. 

A estrutura de cliente e pet foi quebrada em outra tabelas/structs, desta forma, espera-se mais maleabilidade, estar mais próximo a um contexto real e dar mais possibilidade de desenvolvimento a todos.

No entanto, isso aumenta consideravelmente a complexidade da aplicação, ainda mais no que diz respeito ao relacionamento do domínio.